### PR TITLE
- Replaced @Stateless EJB with @Service

### DIFF
--- a/documentation/02-service-migration.md
+++ b/documentation/02-service-migration.md
@@ -1,0 +1,62 @@
+# Service Migration: MemberRegistration EJB to Spring Service
+
+## What was done
+- Located legacy EJB: `org.jboss.as.quickstarts.kitchensink.service.MemberRegistration`
+- Migrated and expanded it into: `com.iskren.service.MemberService`
+- Added missing parity features from the legacy EJB:
+  - Logging on member registration
+  - CDI event firing replaced with Spring `ApplicationEventPublisher`
+- Created Spring event class: `com.iskren.model.MemberRegisteredEvent`
+
+## Key changes
+
+### Legacy EJB (`MemberRegistration`)
+- `@Stateless` → `@Service`
+- `@Inject EntityManager em` → Spring Data JPA via `MemberRepository`
+- `@Inject Event<Member> memberEventSrc` → `ApplicationEventPublisher`
+- `@Inject Logger log` → `private static final Logger log = LoggerFactory.getLogger(...)` (SLF4J)
+- `em.persist(member)` → `memberRepository.save(member)`
+- `memberEventSrc.fire(member)` → `eventPublisher.publishEvent(new MemberRegisteredEvent(member))`
+
+### Spring `MemberService` additions
+- Added `ApplicationEventPublisher` via constructor injection
+- Added SLF4J `Logger` as a static final field (Spring Boot standard — replaces JUL used in legacy JBoss container)
+- Added `log.info("Registering " + member.getName())` before save
+- Added `eventPublisher.publishEvent(new MemberRegisteredEvent(member))` after save
+- Expanded service beyond legacy EJB to include:
+  - `listAllMembers()` — previously in the REST resource directly calling the repository
+  - `lookupMemberById(long id)` — same
+  - `validateMember(Member member)` — previously in the REST resource
+  - `emailAlreadyExists(String email)` — previously in the REST resource
+
+### Refinements applied during review
+- **Logger**: Replaced `java.util.logging.Logger` with SLF4J (`org.slf4j.Logger` / `LoggerFactory`) — Spring Boot routes SLF4J to Logback by default; JUL was a JBoss container concern only
+- **Removed redundant null check**: `if (member == null)` in `createMember` was dead code — Spring never passes `null` for `@RequestBody`; missing/malformed body results in `HttpMessageNotReadableException` before reaching the service
+- **Generic exception handler**: Replaced `@ExceptionHandler(IllegalArgumentException.class)` with `@ExceptionHandler(Exception.class)` in the controller — the legacy `catch (Exception e)` block was a true catch-all returning `{"error": e.getMessage()}` as 400; the previous handler was too narrow
+- **Validation debug log**: Added `log.debug("Validation completed. violations found: " + violations.size())` in `validateMember` — matches legacy `log.fine(...)` in `createViolationResponse`
+
+## Notes
+- The legacy CDI event (`Event<Member>`) had no visible listener in the legacy codebase. In Spring, `MemberRegisteredEvent` can be consumed by any `@EventListener` bean when needed in the future.
+- All business logic is contained in the service layer, keeping the controller thin.
+- Constructor injection is used exclusively — no `@Autowired` on fields.
+
+## Other important information
+- New files:
+  - `src/main/java/com/iskren/model/MemberRegisteredEvent.java`
+- Modified files:
+  - `src/main/java/com/iskren/service/MemberService.java`
+  - `src/main/java/com/iskren/controller/MemberResourceRESTController.java`
+
+## Suggested Commit Message
+```text
+feat: migrate MemberRegistration EJB to Spring Service
+
+- Replaced @Stateless EJB with @Service
+- Added SLF4J logging on member registration (Spring Boot standard)
+- Replaced CDI Event<Member> with Spring ApplicationEventPublisher
+- Created MemberRegisteredEvent for Spring event system
+- Moved validation and registration logic fully into MemberService
+- Removed dead null check on member parameter (handled by @RequestBody)
+- Widened exception handler to catch all Exception types (matching legacy catch-all)
+- Added debug log for constraint violations count (matching legacy log.fine)
+```

--- a/src/main/java/com/iskren/controller/MemberResourceRESTController.java
+++ b/src/main/java/com/iskren/controller/MemberResourceRESTController.java
@@ -69,8 +69,8 @@ public class MemberResourceRESTController {
         return ResponseEntity.status(HttpStatus.CONFLICT).body(Map.of("email", "Email taken"));
     }
 
-    @ExceptionHandler(IllegalArgumentException.class)
-    public ResponseEntity<Map<String, String>> handleIllegalArgument(IllegalArgumentException exception) {
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<Map<String, String>> handleGenericException(Exception exception) {
         return ResponseEntity.badRequest().body(Map.of("error", exception.getMessage()));
     }
 }

--- a/src/main/java/com/iskren/model/MemberRegisteredEvent.java
+++ b/src/main/java/com/iskren/model/MemberRegisteredEvent.java
@@ -1,0 +1,14 @@
+package com.iskren.model;
+
+public class MemberRegisteredEvent {
+
+    private final Member member;
+
+    public MemberRegisteredEvent(Member member) {
+        this.member = member;
+    }
+
+    public Member getMember() {
+        return member;
+    }
+}

--- a/src/main/java/com/iskren/service/MemberService.java
+++ b/src/main/java/com/iskren/service/MemberService.java
@@ -1,6 +1,7 @@
 package com.iskren.service;
 
 import com.iskren.model.Member;
+import com.iskren.model.MemberRegisteredEvent;
 import com.iskren.repository.MemberRepository;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.ConstraintViolationException;
@@ -10,18 +11,25 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class MemberService {
 
+    private static final Logger log = LoggerFactory.getLogger(MemberService.class);
+
     private final MemberRepository memberRepository;
     private final Validator validator;
+    private final ApplicationEventPublisher eventPublisher;
 
-    public MemberService(MemberRepository memberRepository, Validator validator) {
+    public MemberService(MemberRepository memberRepository, Validator validator, ApplicationEventPublisher eventPublisher) {
         this.memberRepository = memberRepository;
         this.validator = validator;
+        this.eventPublisher = eventPublisher;
     }
 
     @Transactional(readOnly = true)
@@ -36,17 +44,16 @@ public class MemberService {
 
     @Transactional
     public void createMember(Member member) {
-        if (member == null) {
-            throw new IllegalArgumentException("Member request body is required");
-        }
-
         validateMember(member);
+        log.info("Registering " + member.getName());
         memberRepository.save(member);
+        eventPublisher.publishEvent(new MemberRegisteredEvent(member));
     }
 
     private void validateMember(Member member) {
         Set<ConstraintViolation<Member>> violations = validator.validate(member);
         if (!violations.isEmpty()) {
+            log.debug("Validation completed. violations found: " + violations.size());
             throw new ConstraintViolationException(new HashSet<>(violations));
         }
 


### PR DESCRIPTION
- Added SLF4J logging on member registration (Spring Boot standard)
- Replaced CDI Event<Member> with Spring ApplicationEventPublisher
- Created MemberRegisteredEvent for Spring event system
- Moved validation and registration logic fully into MemberService
- Removed dead null check on member parameter (handled by @RequestBody)
- Widened exception handler to catch all Exception types (matching legacy catch-all)
- Added debug log for constraint violations count (matching legacy log.fine)