### PR TITLE
- replace JPA/H2 persistence with MongoDB document/repository model

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ The goal of the migration is to preserve the original business behavior (member 
 
 ### Technology Stack
 
-- **Backend:** Java 21, Spring Boot 3.5.13, Spring Web, Spring Data JPA, Jakarta Validation
-- **Database:** H2 (in-memory)
+- **Backend:** Java 21, Spring Boot 3.5.13, Spring Web, Spring Data MongoDB, Jakarta Validation
+- **Database:** MongoDB 8.2 (local)
 - **Frontend:** Vite 8 + React 19
-- **Testing:** JUnit 5, Mockito, MockMvc, Vitest, Testing Library
+- **Testing:** JUnit 5, Mockito, MockMvc, Vitest, Testing Library, Flapdoodle Embedded MongoDB
 
 ### Main Features
 
@@ -37,8 +37,9 @@ The migration was executed in incremental layers to reduce risk and preserve par
    - Legacy EJB logic was moved into a Spring `@Service` (`MemberService`) using constructor injection.
    - Legacy event behavior was preserved using Spring `ApplicationEventPublisher`.
 3. **Persistence migration**
-   - Legacy persistence configuration was replaced with Spring Boot configuration in `application.properties`.
-   - Seed data behavior was preserved with `import.sql`.
+   - Legacy JPA/H2 persistence replaced with Spring Data MongoDB (`application.properties`).
+   - Seed data migrated from `import.sql` (Hibernate DDL) to `DataSeeder.java` (`CommandLineRunner`).
+   - Stretch goal fulfilled: MongoDB is the persistence target (latest stable MongoDB 8.2).
 4. **Frontend modernization**
    - JSF/CND-style frontend workflow was replaced with modular Vite + React architecture.
    - React bundle is built into Spring Boot static resources for production serving.
@@ -55,7 +56,8 @@ The migration was executed in incremental layers to reduce risk and preserve par
   - EJB `@Stateless` service -> Spring `@Service`
 - Introduced clear package boundaries under `com.iskren`:
   - `controller`, `service`, `repository`, `model`
-- Replaced persistence bootstrap with Spring Data JPA + H2 configuration.
+- Replaced persistence bootstrap with Spring Data MongoDB configuration.
+- Fulfilled optional stretch goal: MongoDB 8.2 is the persistence layer.
 - Preserved and formalized API error contract for validation/conflict scenarios.
 - Upgraded frontend to componentized React structure with dedicated API service module.
 - Added modern, automated tests across backend and frontend.
@@ -73,12 +75,12 @@ kitchensink-modernized/
 │  │  ├─ java/com/iskren/
 │  │  │  ├─ controller/                 # REST API controllers
 │  │  │  ├─ service/                    # Business logic
-│  │  │  ├─ repository/                 # Spring Data JPA repositories
-│  │  │  ├─ model/                      # Entities + event model
+│  │  │  ├─ config/                     # DataSeeder (seed data on startup)
+│  │  │  ├─ repository/                 # Spring Data MongoDB repositories
+│  │  │  ├─ model/                      # Documents + event model
 │  │  │  └─ kitchensink_modernized/     # Spring Boot application entrypoint
 │  │  └─ resources/
-│  │     ├─ application.properties      # Runtime config
-│  │     ├─ import.sql                  # Seed data
+│  │     ├─ application.properties      # Runtime config (MongoDB URI)
 │  │     └─ static/                     # Static resources served by Spring Boot
 │  └─ test/java/com/iskren/             # Backend tests
 ├─ frontend/
@@ -109,28 +111,30 @@ kitchensink-modernized/
 From `src/main/resources/application.properties`:
 
 - `server.port=8081`
-- `spring.datasource.url=jdbc:h2:mem:kitchensink;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE`
-- `spring.datasource.username=sa`
-- `spring.datasource.password=`
-- `spring.jpa.hibernate.ddl-auto=create-drop`
+- `spring.data.mongodb.host=localhost`
+- `spring.data.mongodb.port=27017`
+- `spring.data.mongodb.database=kitchensink`
+- `spring.data.mongodb.auto-index-creation=true`
 
 ### Database Setup
 
-- Database is **H2 in-memory** for local development/testing.
-- Initial seed row is loaded from `src/main/resources/import.sql`.
-- Schema is recreated at startup (`create-drop`).
+- Database is **MongoDB** running locally on the default port `27017`.
+- The database `kitchensink` is created automatically by MongoDB on first use.
+- Initial seed data (John Smith) is inserted by `DataSeeder.java` at startup if the collection is empty.
+- Data **persists across restarts** (unlike the previous H2 `create-drop` behavior).
+- To reset the database, drop the `kitchensink` database in your MongoDB client:
+  ```bash
+  mongosh
+  use kitchensink
+  db.dropDatabase()
+  ```
 
 ### Environment Variables (Optional Overrides)
 
-No custom environment variables are required to run the app.
+You can override the MongoDB URI via an environment variable:
 
-You can override standard Spring properties when needed, for example:
-
-- `SERVER_PORT`
-- `SPRING_DATASOURCE_URL`
-- `SPRING_DATASOURCE_USERNAME`
-- `SPRING_DATASOURCE_PASSWORD`
-- `SPRING_JPA_HIBERNATE_DDL_AUTO`
+- `SPRING_DATA_MONGODB_HOST` / `SPRING_DATA_MONGODB_PORT` / `SPRING_DATA_MONGODB_DATABASE` — or use `SPRING_DATA_MONGODB_URI` to set the full connection string
+- `SERVER_PORT` — override the HTTP port (default `8081`)
 
 ### Ports
 
@@ -144,6 +148,7 @@ You can override standard Spring properties when needed, for example:
 ### Prerequisites
 
 - Java 21
+- **MongoDB 8.2** running locally on port `27017` ([Download MongoDB Community](https://www.mongodb.com/try/download/community))
 - Node.js (compatible with Vite 8; recommended modern LTS)
 - npm
 - Maven (or use included Maven wrapper)
@@ -264,32 +269,37 @@ Current verified status:
 
 ## 8) Known Limitations / Trade-offs
 
-- Current database is in-memory H2 with `create-drop` (not persistent across restarts).
+- MongoDB must be running locally before starting the application (`mongod` on port `27017`).
+- MongoDB multi-document transactions require a replica set; the current single-node setup does not support them (not required for this application).
+- Member IDs are MongoDB ObjectId hex strings rather than small integers; links bookmarked to `/rest/members/1` will not resolve on a fresh database.
 - No end-to-end browser test suite yet (unit/integration coverage is strong, but E2E is not included).
 - Frontend production bundle is generated and committed as a static artifact, which is convenient for demo parity but can increase diff size.
+- First backend test run downloads a MongoDB 8.2.0 binary via Flapdoodle (embedded, `de.flapdoodle.embed.mongo.spring3x:4.24.0`); this requires an internet connection and adds ~10–30 seconds on first use. Subsequent runs use the cached binary.
 
 ---
 
 ## 9) Future Improvements
 
-- Add better database configuration by using MongoDB and production-like environments.
+- Add a MongoDB replica set profile for transactional support and production-like environments.
 - Add CI pipeline (build + tests + coverage reports + quality gates).
 - Add E2E tests (e.g., Playwright) for full browser-to-backend verification.
 - Add observability enhancements (structured logs, metrics, health dashboards).
-- Add containerization (`Dockerfile` + Compose) for reproducible local setup.
+- Add containerization (`Dockerfile` + Docker Compose with MongoDB service) for reproducible local setup.
 
 ---
 
 ## 10) References
 
 - Legacy JBoss Kitchensink source used for migration:
-  - `C:\Users\user\Desktop\MongoDBLearning\KitchensinkModernized\kitchensink`
+  - `https://github.com/jboss-developer/jboss-eap-quickstarts/tree/8.0.x/kitchensink`
 - Red Hat JBoss EAP Quickstarts repository:
   - https://github.com/jboss-developer/jboss-eap-quickstarts
 - Spring Boot documentation:
   - https://docs.spring.io/spring-boot/docs/current/reference/html/
-- Spring Data JPA documentation:
-  - https://docs.spring.io/spring-data/jpa/reference/
+- Spring Data MongoDB documentation:
+  - https://docs.spring.io/spring-data/mongodb/reference/
+- MongoDB 8.2 release notes:
+  - https://www.mongodb.com/docs/manual/release-notes/8.2/
 - Vite documentation:
   - https://vite.dev/
 - React documentation:
@@ -300,3 +310,4 @@ Current verified status:
   - `documentation/03-persistence-migration.md`
   - `documentation/04-frontend-integration.md`
   - `documentation/05-testing.md`
+  - `documentation/06-mongodb-migration.md`

--- a/documentation/05-testing.md
+++ b/documentation/05-testing.md
@@ -92,10 +92,10 @@ Covers:
 ### 3. `MemberRepositoryTest` — Repository Integration Tests
 
 **Location**: `src/test/java/com/iskren/repository/MemberRepositoryTest.java`  
-**Type**: Integration test (`@SpringBootTest` + H2 in-memory DB + `@Transactional`)  
+**Type**: Integration test (`@SpringBootTest` + Flapdoodle embedded MongoDB 8.2.0)  
 **Context**: Full application context, `webEnvironment = NONE`
 
-Each test runs inside a transaction that rolls back, keeping tests isolated. `@BeforeEach` deletes the seed row from `import.sql` (`John Smith`).
+Each test uses `@BeforeEach` with `deleteAll()` to wipe the collection before running, keeping tests isolated (no transactional rollback — MongoDB on a single node does not support it without a replica set).
 
 Covers:
 

--- a/documentation/06-mongodb-migration.md
+++ b/documentation/06-mongodb-migration.md
@@ -1,0 +1,164 @@
+# MongoDB Migration: H2 (JPA) to MongoDB
+
+## What was done
+
+Migrated the persistence layer from Spring Data JPA with an H2 in-memory relational database to Spring Data MongoDB (MongoDB 8.x). All REST endpoints, validation rules, and error responses remain unchanged.
+
+---
+
+## Why MongoDB was chosen
+
+The optional stretch goal in the challenge brief specified MongoDB as the target database. Beyond fulfilling the brief, MongoDB is a natural fit for this workload:
+
+- **Document model**: A `Member` is a self-contained document with no joins — it maps cleanly to a MongoDB document without the overhead of a relational schema.
+- **Schema flexibility**: Member fields can evolve without DDL migrations or schema version locks.
+- **MongoDB + Spring Boot**: First-class support via `spring-boot-starter-data-mongodb`; Spring Data's repository abstraction (`MongoRepository`) mirrors `JpaRepository`, minimising migration surface.
+- **Stretch goal alignment**: The project brief and challenge context explicitly mention MongoDB integration as the target.
+
+---
+
+## Key changes
+
+### 1. `pom.xml`
+
+| Before | After |
+|---|---|
+| `spring-boot-starter-data-jpa` | `spring-boot-starter-data-mongodb` |
+| `com.h2database:h2` (runtime) | `de.flapdoodle.embed:de.flapdoodle.embed.mongo.spring3x` (test) |
+
+Flapdoodle provides an embedded MongoDB process for tests, replacing the role H2 played for in-memory JPA tests.
+
+### 2. `Member.java`
+
+| Before (JPA) | After (MongoDB) |
+|---|---|
+| `@Entity` | `@Document(collection = "members")` |
+| `@Table(uniqueConstraints = ...)` | Removed; uniqueness enforced via `@Indexed(unique = true)` on `email` |
+| `@Id` (jakarta.persistence) | `@Id` (org.springframework.data.annotation) |
+| `@GeneratedValue(IDENTITY)` | Removed; MongoDB auto-generates ObjectId |
+| `@Column(name = "phone_number")` | Removed; field stored under Java property name `phoneNumber` |
+| `private Long id` | `private String id` |
+
+MongoDB generates IDs as 24-character hex ObjectId strings. The ID type change from `Long` to `String` is the most visible downstream change.
+
+### 3. `MemberRepository.java`
+
+```java
+// Before
+extends JpaRepository<Member, Long>
+
+// After
+extends MongoRepository<Member, String>
+```
+
+Custom query methods (`findByEmail`, `findAllByOrderByNameAsc`) are unchanged — Spring Data derives the same queries for MongoDB.
+
+### 4. `MemberService.java`
+
+`lookupMemberById` signature changed from `long id` to `String id` to match the repository's ID type.
+
+### 5. `MemberResourceRESTController.java`
+
+The path variable pattern was changed from `/{id:[0-9][0-9]*}` (numeric-only) to `/{id}` because MongoDB ObjectIds are hex strings, not integers. The `@PathVariable` type changed from `long` to `String`. Observable API behaviour is identical: a non-existent ID returns `404`.
+
+### 6. `KitchensinkModernizedApplication.java`
+
+Removed `@EntityScan` and `@EnableJpaRepositories` — these were JPA bootstrap annotations. Spring Data MongoDB is auto-configured by `@SpringBootApplication(scanBasePackages = "com.iskren")` alone.
+
+### 7. `application.properties`
+
+Removed all `spring.datasource.*` and `spring.jpa.*` properties. Added:
+
+```properties
+spring.data.mongodb.uri=mongodb://localhost:27017/kitchensink
+spring.data.mongodb.auto-index-creation=true
+```
+
+`auto-index-creation=true` causes Spring Data to create the unique index on `email` (declared via `@Indexed(unique = true)`) at application startup.
+
+### 8. Seed data: `import.sql` → `DataSeeder.java`
+
+The H2 `import.sql` (which was executed by Hibernate DDL) has no equivalent in MongoDB. A `CommandLineRunner` component (`com.iskren.config.DataSeeder`) replaces it:
+
+```java
+@Override
+public void run(String... args) {
+    if (memberRepository.count() == 0) {
+        // insert John Smith
+    }
+}
+```
+
+The check `count() == 0` prevents duplicate seeding across restarts (MongoDB is persistent, unlike H2 `create-drop`).
+
+---
+
+## Key differences vs relational database
+
+| Concern | H2 / JPA | MongoDB |
+|---|---|---|
+| Schema | Fixed DDL (`create-drop`) | Schemaless documents |
+| ID type | `Long` (auto-increment) | `String` (ObjectId hex) |
+| Uniqueness | `@UniqueConstraint` on `@Table` | `@Indexed(unique = true)` on field |
+| Seed data | `import.sql` via Hibernate DDL | `CommandLineRunner` (`DataSeeder`) |
+| Transactions | JPA `@Transactional` with JDBC rollback | MongoDB transactions require replica set |
+| Test isolation | `@Transactional` rollback on test method | `deleteAll()` in `@BeforeEach` |
+| Connection | JDBC datasource | MongoDB URI |
+| Data persistence | Wiped on restart (`create-drop`) | Persists across restarts |
+
+---
+
+## Trade-offs and considerations
+
+### Persistence across restarts
+
+H2 with `create-drop` recreated the schema (and seed data) on every startup. MongoDB persists data across restarts. The `DataSeeder` guards against re-inserting the seed row (`count() == 0`), but any member data registered during a previous run is retained. This is the correct production behaviour; for a fresh-start dev environment, the `kitchensink` database can be dropped manually.
+
+### Transaction support
+
+Standard multi-document transactions in MongoDB require a replica set. For local development with a single standalone node, `@Transactional` on service methods has no effect. The application does not use multi-document transactions (each operation is a single document save/find), so this is not a functional limitation. For production deployments, a replica set is recommended to enable transactional guarantees if needed.
+
+### ID format change
+
+Member IDs are now 24-character hex strings (e.g. `"683abc1234def5678901234a"`) instead of small integers. The REST API path `/rest/members/{id}` still works correctly. Any client that was hard-coding numeric IDs (e.g. bookmarks to `/rest/members/1`) will need to use the IDs returned from `GET /rest/members` instead.
+
+### Test embedded MongoDB (Flapdoodle)
+
+The `de.flapdoodle.embed.mongo.spring3x` dependency downloads a real MongoDB binary the first time tests run. This requires an internet connection on the first run and adds ~10–30 seconds to the initial test execution while the binary is downloaded and cached. Subsequent runs use the cached binary.
+
+The embedded version is pinned to **MongoDB 8.2.0** via `src/test/resources/application.properties`:
+
+```properties
+de.flapdoodle.mongodb.embedded.version=8.2.0
+```
+
+Verified on Windows x86_64 with `de.flapdoodle.embed.mongo.spring3x:4.24.0`: embedded MongoDB 8.2.0 starts correctly and the full backend test suite passes.
+
+---
+
+## Files changed
+
+| File | Change |
+|---|---|
+| `pom.xml` | Replaced JPA/H2 with MongoDB + Flapdoodle test dep |
+| `src/main/java/com/iskren/model/Member.java` | `@Document`, `String id`, `@Indexed(unique=true)` |
+| `src/main/java/com/iskren/repository/MemberRepository.java` | `MongoRepository<Member, String>` |
+| `src/main/java/com/iskren/service/MemberService.java` | `lookupMemberById(String id)` |
+| `src/main/java/com/iskren/controller/MemberResourceRESTController.java` | `/{id}` path, `String id` parameter |
+| `src/main/java/com/iskren/kitchensink_modernized/KitchensinkModernizedApplication.java` | Removed `@EntityScan` / `@EnableJpaRepositories`; added `@EnableMongoRepositories(basePackages = "com.iskren.repository")` |
+| `src/main/resources/application.properties` | MongoDB host/port/database + auto-index-creation |
+| `src/main/resources/import.sql` | Cleared (superseded by DataSeeder) |
+| `src/main/java/com/iskren/config/DataSeeder.java` | **New** — seeds John Smith if collection empty |
+| `src/test/java/com/iskren/repository/MemberRepositoryTest.java` | Removed `@Transactional`; `deleteAll()` in `@BeforeEach`; `String` ID |
+| `src/test/java/com/iskren/service/MemberServiceTest.java` | `String` ID literals in `lookupMemberById` tests |
+| `src/test/java/com/iskren/controller/MemberResourceRESTControllerTest.java` | `String` ID in helper and all assertions |
+| `src/test/resources/application.properties` | **New** — pins Flapdoodle embedded MongoDB version to 8.2.0 |
+
+## Files unchanged
+
+| File | Reason |
+|---|---|
+| `src/test/java/com/iskren/model/MemberValidationTest.java` | Pure Jakarta Validation unit test; no persistence |
+| `src/test/java/com/iskren/service/MemberServiceTest.java` (business logic tests) | Mockito-only; only ID-type stubs updated |
+| `frontend/` (all) | No frontend changes; REST contract is identical |
+| `vite.config.js`, `vitest.config.js`, `package.json` | No frontend changes |

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-data-jpa</artifactId>
+			<artifactId>spring-boot-starter-data-mongodb</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -44,9 +44,10 @@
 		</dependency>
 
 		<dependency>
-			<groupId>com.h2database</groupId>
-			<artifactId>h2</artifactId>
-			<scope>runtime</scope>
+			<groupId>de.flapdoodle.embed</groupId>
+			<artifactId>de.flapdoodle.embed.mongo.spring3x</artifactId>
+			<version>4.24.0</version>
+			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/src/main/java/com/iskren/config/DataSeeder.java
+++ b/src/main/java/com/iskren/config/DataSeeder.java
@@ -1,0 +1,27 @@
+package com.iskren.config;
+
+import com.iskren.model.Member;
+import com.iskren.repository.MemberRepository;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DataSeeder implements CommandLineRunner {
+
+    private final MemberRepository memberRepository;
+
+    public DataSeeder(MemberRepository memberRepository) {
+        this.memberRepository = memberRepository;
+    }
+
+    @Override
+    public void run(String... args) {
+        if (memberRepository.count() == 0) {
+            Member member = new Member();
+            member.setName("John Smith");
+            member.setEmail("john.smith@mailinator.com");
+            member.setPhoneNumber("2125551212");
+            memberRepository.save(member);
+        }
+    }
+}

--- a/src/main/java/com/iskren/controller/MemberResourceRESTController.java
+++ b/src/main/java/com/iskren/controller/MemberResourceRESTController.java
@@ -35,8 +35,8 @@ public class MemberResourceRESTController {
         return memberService.listAllMembers();
     }
 
-    @GetMapping(path = "/{id:[0-9][0-9]*}", produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<Member> lookupMemberById(@PathVariable long id) {
+    @GetMapping(path = "/{id}", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<Member> lookupMemberById(@PathVariable String id) {
         return memberService.lookupMemberById(id)
                 .map(ResponseEntity::ok)
                 .orElseGet(() -> ResponseEntity.notFound().build());

--- a/src/main/java/com/iskren/kitchensink_modernized/KitchensinkModernizedApplication.java
+++ b/src/main/java/com/iskren/kitchensink_modernized/KitchensinkModernizedApplication.java
@@ -2,12 +2,10 @@ package com.iskren.kitchensink_modernized;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.domain.EntityScan;
-import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
 
 @SpringBootApplication(scanBasePackages = "com.iskren")
-@EntityScan(basePackages = "com.iskren.model")
-@EnableJpaRepositories(basePackages = "com.iskren.repository")
+@EnableMongoRepositories(basePackages = "com.iskren.repository")
 public class KitchensinkModernizedApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/iskren/model/Member.java
+++ b/src/main/java/com/iskren/model/Member.java
@@ -1,26 +1,20 @@
 package com.iskren.model;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
-import jakarta.persistence.UniqueConstraint;
 import jakarta.validation.constraints.Digits;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.index.Indexed;
+import org.springframework.data.mongodb.core.mapping.Document;
 
-@Entity
-@Table(uniqueConstraints = @UniqueConstraint(columnNames = "email"))
+@Document(collection = "members")
 public class Member {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+    private String id;
 
     @NotNull
     @Size(min = 1, max = 25)
@@ -29,19 +23,19 @@ public class Member {
 
     @NotBlank
     @Email
+    @Indexed(unique = true)
     private String email;
 
     @NotNull
     @Size(min = 10, max = 12)
     @Digits(fraction = 0, integer = 12)
-    @Column(name = "phone_number")
     private String phoneNumber;
 
-    public Long getId() {
+    public String getId() {
         return id;
     }
 
-    public void setId(Long id) {
+    public void setId(String id) {
         this.id = id;
     }
 

--- a/src/main/java/com/iskren/repository/MemberRepository.java
+++ b/src/main/java/com/iskren/repository/MemberRepository.java
@@ -3,9 +3,9 @@ package com.iskren.repository;
 import com.iskren.model.Member;
 import java.util.List;
 import java.util.Optional;
-import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.mongodb.repository.MongoRepository;
 
-public interface MemberRepository extends JpaRepository<Member, Long> {
+public interface MemberRepository extends MongoRepository<Member, String> {
 
     Optional<Member> findByEmail(String email);
 

--- a/src/main/java/com/iskren/service/MemberService.java
+++ b/src/main/java/com/iskren/service/MemberService.java
@@ -38,7 +38,7 @@ public class MemberService {
     }
 
     @Transactional(readOnly = true)
-    public Optional<Member> lookupMemberById(long id) {
+    public Optional<Member> lookupMemberById(String id) {
         return memberRepository.findById(id);
     }
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,10 +1,6 @@
 spring.application.name=kitchensink-modernized
 server.port=8081
-spring.datasource.url=jdbc:h2:mem:kitchensink;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
-spring.datasource.driver-class-name=org.h2.Driver
-spring.datasource.username=sa
-spring.datasource.password=
-spring.jpa.hibernate.ddl-auto=create-drop
-spring.jpa.show-sql=false
-spring.jpa.properties.hibernate.format_sql=false
-spring.jpa.open-in-view=false
+spring.data.mongodb.host=localhost
+spring.data.mongodb.port=27017
+spring.data.mongodb.database=kitchensink
+spring.data.mongodb.auto-index-creation=true

--- a/src/main/resources/import.sql
+++ b/src/main/resources/import.sql
@@ -1,1 +1,0 @@
-insert into Member (id, name, email, phone_number) values (0, 'John Smith', 'john.smith@mailinator.com', '2125551212')

--- a/src/main/resources/static/css/screen.css
+++ b/src/main/resources/static/css/screen.css
@@ -183,38 +183,36 @@ span.invalid {
 .table-scroll {
   width: 100%;
   border-radius: inherit;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
 }
 
 .table-shell {
   width: 100%;
-  max-width: 560px;
   border: 1px solid var(--line);
   border-radius: 10px;
   background: #ffffff;
   box-shadow: 0 8px 20px rgba(36, 52, 70, 0.08);
-  overflow: hidden;
 }
 
 .simpletablestyle {
-  width: 100%;
-  max-width: none;
+  width: max-content;
+  min-width: 100%;
   border-collapse: collapse;
 }
 
-.simpletablestyle td {
+.simpletablestyle th, .simpletablestyle td {
   padding: 8px 10px;
   font-size: 12px;
+  white-space: nowrap;
 }
 
 .simpletablestyle th {
   background: linear-gradient(180deg, #2a3138 0%, #1f252b 100%);
-  font-size: 12px;
   font-weight: 500;
   color: #fff;
-  padding: 9px 10px;
   text-align: left;
 }
-
 .simpletablestyle tr:nth-child(odd) {
   background: #f9fbfc;
 }

--- a/src/test/java/com/iskren/controller/MemberResourceRESTControllerTest.java
+++ b/src/test/java/com/iskren/controller/MemberResourceRESTControllerTest.java
@@ -33,7 +33,7 @@ class MemberResourceRESTControllerTest {
     @MockitoBean
     private MemberService memberService;
 
-    private Member member(long id, String name, String email) {
+    private Member member(String id, String name, String email) {
         Member m = new Member();
         m.setId(id);
         m.setName(name);
@@ -47,8 +47,8 @@ class MemberResourceRESTControllerTest {
     @Test
     void GET_members_returns200WithJsonArray() throws Exception {
         when(memberService.listAllMembers()).thenReturn(List.of(
-                member(1L, "Alice", "alice@example.com"),
-                member(2L, "Bob", "bob@example.com")
+                member("1", "Alice", "alice@example.com"),
+                member("2", "Bob", "bob@example.com")
         ));
 
         mockMvc.perform(get("/rest/members").accept(MediaType.APPLICATION_JSON))
@@ -72,11 +72,11 @@ class MemberResourceRESTControllerTest {
     @Test
     void GET_members_responseIncludesAllMemberFields() throws Exception {
         when(memberService.listAllMembers()).thenReturn(List.of(
-                member(1L, "Alice", "alice@example.com")
+                member("1", "Alice", "alice@example.com")
         ));
 
         mockMvc.perform(get("/rest/members").accept(MediaType.APPLICATION_JSON))
-                .andExpect(jsonPath("$[0].id").value(1))
+                .andExpect(jsonPath("$[0].id").value("1"))
                 .andExpect(jsonPath("$[0].name").value("Alice"))
                 .andExpect(jsonPath("$[0].email").value("alice@example.com"))
                 .andExpect(jsonPath("$[0].phoneNumber").value("2125551212"));
@@ -86,20 +86,20 @@ class MemberResourceRESTControllerTest {
 
     @Test
     void GET_memberById_whenFound_returns200WithMember() throws Exception {
-        when(memberService.lookupMemberById(1L)).thenReturn(
-                Optional.of(member(1L, "Alice", "alice@example.com"))
+        when(memberService.lookupMemberById("1")).thenReturn(
+                Optional.of(member("1", "Alice", "alice@example.com"))
         );
 
         mockMvc.perform(get("/rest/members/1").accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.id").value(1))
+                .andExpect(jsonPath("$.id").value("1"))
                 .andExpect(jsonPath("$.name").value("Alice"))
                 .andExpect(jsonPath("$.email").value("alice@example.com"));
     }
 
     @Test
     void GET_memberById_whenNotFound_returns404() throws Exception {
-        when(memberService.lookupMemberById(99L)).thenReturn(Optional.empty());
+        when(memberService.lookupMemberById("99")).thenReturn(Optional.empty());
 
         mockMvc.perform(get("/rest/members/99").accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isNotFound());

--- a/src/test/java/com/iskren/repository/MemberRepositoryTest.java
+++ b/src/test/java/com/iskren/repository/MemberRepositoryTest.java
@@ -6,7 +6,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Optional;
@@ -15,7 +14,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest(classes = KitchensinkModernizedApplication.class,
         webEnvironment = SpringBootTest.WebEnvironment.NONE)
-@Transactional
 class MemberRepositoryTest {
 
     @Autowired
@@ -112,7 +110,7 @@ class MemberRepositoryTest {
 
     @Test
     void findById_whenNotFound_returnsEmptyOptional() {
-        Optional<Member> result = memberRepository.findById(9999L);
+        Optional<Member> result = memberRepository.findById("nonexistent-id");
 
         assertThat(result).isEmpty();
     }

--- a/src/test/java/com/iskren/service/MemberServiceTest.java
+++ b/src/test/java/com/iskren/service/MemberServiceTest.java
@@ -81,18 +81,18 @@ class MemberServiceTest {
     @Test
     void lookupMemberById_whenFound_returnsMemberInOptional() {
         Member m = validMember();
-        when(memberRepository.findById(1L)).thenReturn(Optional.of(m));
+        when(memberRepository.findById("1")).thenReturn(Optional.of(m));
 
-        Optional<Member> result = memberService.lookupMemberById(1L);
+        Optional<Member> result = memberService.lookupMemberById("1");
 
         assertThat(result).contains(m);
     }
 
     @Test
     void lookupMemberById_whenNotFound_returnsEmptyOptional() {
-        when(memberRepository.findById(99L)).thenReturn(Optional.empty());
+        when(memberRepository.findById("99")).thenReturn(Optional.empty());
 
-        Optional<Member> result = memberService.lookupMemberById(99L);
+        Optional<Member> result = memberService.lookupMemberById("99");
 
         assertThat(result).isEmpty();
     }

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,0 +1,1 @@
+de.flapdoodle.mongodb.embedded.version=8.2.0


### PR DESCRIPTION
- switch Member ID handling from Long to String/ObjectId across service, controller, and tests
- add MongoDB seeding and Spring Mongo repository configuration
- configure embedded MongoDB for tests (Flapdoodle + pinned version)
- update REST error handling/validation behavior to preserve legacy parity
- update UI table handling for long Mongo ObjectIds (horizontal scrolling)
- remove obsolete SQL seed artifact (import.sql)
- refresh migration documentation and related project configs